### PR TITLE
fix: P64 call-site IndexError when streaming tool calls on finish

### DIFF
--- a/vllm/_genesis/wiring/patch_64_qwen3coder_mtp_streaming.py
+++ b/vllm/_genesis/wiring/patch_64_qwen3coder_mtp_streaming.py
@@ -198,6 +198,44 @@ SERVING_SHOULD_NEW = (
 )
 
 
+# ─── Sub-patch E: serving.py — call-site guard for tool_calls[0] ────────────
+# P64's widened _should_check returns True on finish_reason alone (no tool_calls
+# required). The call site in chat_completion_stream_generator then accesses
+# delta_message.tool_calls[0] unconditionally → IndexError when the final
+# streaming delta carries tool calls in prev_tool_call_arr but an empty
+# delta_message.tool_calls list. Guard the inner `if` before [0] access.
+
+SERVING_CALLSITE_OLD = (
+    "                        if should_check and tool_parser and auto_tools_called:\n"
+    "                            latest_delta_len = 0\n"
+    "                            if (\n"
+    "                                isinstance(\n"
+    "                                    delta_message.tool_calls[0].function,\n"
+    "                                    DeltaFunctionCall,\n"
+    "                                )\n"
+    "                            ) and isinstance(\n"
+    "                                delta_message.tool_calls[0].function.arguments, str\n"
+    "                            ):\n"
+)
+
+SERVING_CALLSITE_NEW = (
+    "                        if should_check and tool_parser and auto_tools_called:\n"
+    "                            latest_delta_len = 0\n"
+    "                            # [Genesis P64 call-site guard] _should_check\n"
+    "                            # fires on finish_reason alone; tool_calls may\n"
+    "                            # be [] on the final delta — guard before [0].\n"
+    "                            if (\n"
+    "                                delta_message.tool_calls\n"
+    "                                and isinstance(\n"
+    "                                    delta_message.tool_calls[0].function,\n"
+    "                                    DeltaFunctionCall,\n"
+    "                                )\n"
+    "                            ) and isinstance(\n"
+    "                                delta_message.tool_calls[0].function.arguments, str\n"
+    "                            ):\n"
+)
+
+
 # ─── Sub-patch D: serving.py — _create_remaining_args_delta Pydantic fix ────
 
 SERVING_CRD_OLD = (
@@ -279,6 +317,8 @@ def _make_serving_patcher() -> TextPatcher | None:
         sub_patches=[
             TextPatch(name="p64_safety_net_widen", anchor=SERVING_SHOULD_OLD,
                       replacement=SERVING_SHOULD_NEW, required=True),
+            TextPatch(name="p64_callsite_guard", anchor=SERVING_CALLSITE_OLD,
+                      replacement=SERVING_CALLSITE_NEW, required=True),
             # NOTE: D sub-patch DUPLICATES the original return for the second
             # half of _create_remaining_args_delta to keep the function shape
             # syntactically valid (the original DeltaFunctionCall line


### PR DESCRIPTION
## Problem

chat_completion_stream_generator crashes with IndexError: list index out of range on the final streaming chunk of any tool call response:

```
  File "vllm/entrypoints/openai/chat_completion/serving.py", line 1128
      delta_message.tool_calls[0].function,
  IndexError: list index out of range
```

` Expected 'id' to be a string`

## Root cause

Genesis P64 (GENESIS_ENABLE_P64_QWEN3CODER_MTP_STREAMING) widened _should_check_for_unstreamed_tool_arg_tokens to return True on finish_reason alone — intentionally, to handle MTP/spec-decode finals where tool calls are in progress but the last delta carries no tool_calls chunk.

However, the call site in chat_completion_stream_generator was not updated to match. It checks should_check and tool_parser and auto_tools_called (the last guard confirms prev_tool_call_arr is non-empty, i.e. a tool call is in progress), then immediately accesses delta_message.tool_calls[0] with no guard on the list length. When the final delta has tool_calls = [], this crashes.