### PR TITLE
Fix P101 anchor drift on vLLM dev205+ (silent no-op)

### DIFF
--- a/vllm/_genesis/wiring/patch_101_tq_continuation_slicing.py
+++ b/vllm/_genesis/wiring/patch_101_tq_continuation_slicing.py
@@ -91,8 +91,12 @@ P101_LOOP_OLD = (
     "                if q_len <= _CONTINUATION_DECODE_THRESHOLD:\n"
     "                    # Fast path: treat each query as a decode request\n"
     "                    # with incremental seq_lens for causal masking.\n"
-    "                    # Slice from pre-built arange (no kernel launch)\n"
-    "                    synth_seq_lens = _arange_cache[cached_len + 1 : seq_len + 1]\n"
+    "                    synth_seq_lens = torch.arange(\n"
+    "                        cached_len + 1,\n"
+    "                        seq_len + 1,\n"
+    "                        device=query.device,\n"
+    "                        dtype=attn_metadata.seq_lens.dtype,\n"
+    "                    )\n"
     "                    synth_bt = attn_metadata.block_table[i : i + 1].expand(q_len, -1)\n"
     "                    out = triton_turboquant_decode_attention(\n"
     "                        query=q_seq,\n"
@@ -133,10 +137,12 @@ P101_LOOP_NEW = (
     "                        q_part = q_seq[q_offset:q_next]\n"
     "                        part_len = q_next - q_offset\n"
     "                        output_part = out[q_offset:q_next]\n"
-    "                        # Slice from pre-built arange (no kernel launch)\n"
-    "                        synth_seq_lens = _arange_cache[\n"
-    "                            cached_len + q_offset + 1 : cached_len + q_next + 1\n"
-    "                        ]\n"
+    "                        synth_seq_lens = torch.arange(\n"
+    "                            cached_len + q_offset + 1,\n"
+    "                            cached_len + q_next + 1,\n"
+    "                            device=query.device,\n"
+    "                            dtype=attn_metadata.seq_lens.dtype,\n"
+    "                        )\n"
     "                        synth_bt = attn_metadata.block_table[i : i + 1].expand(\n"
     "                            part_len, -1\n"
     "                        )\n"
@@ -232,6 +238,12 @@ def apply() -> tuple[str, str]:
         return "failed", (
             f"{patcher.patch_name}: "
             f"{failure.reason if failure else 'unknown'} "
+            f"({failure.detail if failure else ''})"
+        )
+    if result not in (TextPatchResult.APPLIED, TextPatchResult.IDEMPOTENT):
+        return result.value, (
+            f"{patcher.patch_name}: "
+            f"{failure.reason if failure else 'not applied'} "
             f"({failure.detail if failure else ''})"
         )
 


### PR DESCRIPTION
## Summary

P101's text-replace anchor doesn't match the current upstream `vllm/v1/attention/backends/turboquant_attn.py` on vLLM dev205+, so the patch silently no-ops. `apply_all` reports `"P101 applied"` because `TextPatcher.apply()` returns without raising, but the installed file is unchanged.

## Symptom

After enabling `GENESIS_ENABLE_P101=1` on a current vLLM nightly:

```
[INFO:genesis.apply_all] [Genesis] applied: P101 TQ continuation 64-token slicing
```

But `_CONTINUATION_DECODE_THRESHOLD` in the installed file remains `128` (not the new `64`), `_CONTINUATION_DECODE_MAX_CACHED_LEN` is absent, and the `use_decode_continuation` gating block is not injected. The continuation prefill falls into the original large-continuation branch instead of the sliced TQ-decode path P101 is meant to route through.

## Root cause

Upstream replaced the older `_arange_cache[cached_len + 1 : seq_len + 1]` slicing with inline `torch.arange(cached_len + 1, seq_len + 1, ...)` in two locations inside `_continuation_prefill`. P101's `P101_LOOP_OLD` anchor still expects the `_arange_cache` form, so the regex / string match fails and no replacement is performed. Because the surrounding `TextPatch` returns success when *no* lines match (idempotency-friendly behavior), the failure is silent.

## Fix

Update `P101_LOOP_OLD` and `P101_LOOP_NEW` to use the inline `torch.arange(...)` form. Anchor and replacement bodies adjusted in both occurrences; idempotency marker and apply-log unchanged.

## Verification

Tested on RTX 3090 + Qwen3.6-27B AutoRound INT4 + vLLM `dev205+g07351e088` + `GENESIS_ENABLE_P101=1`. After the fix, the installed `turboquant_attn.py` shows:
- `_CONTINUATION_DECODE_THRESHOLD = 64`
- `_CONTINUATION_DECODE_MAX_CACHED_LEN = 32768`
- `use_decode_continuation = (q_len <= ... or cached_len >= ...)` gating block

## Trade-off note

This change makes P101 work on dev205+ but breaks the anchor on older vLLM versions still using `_arange_cache`. Two paths if you want full back-compat:

1. **Multi-anchor TextPatch** — try `_arange_cache` form first, fall back to `torch.arange` form (or vice versa). Keeps both vLLM lines working.
2. **Pin minimum vLLM version** — document P101 as `dev205+`-only in the dispatcher metadata.

I left it as a single-anchor change matching the most recent vLLM form (option 2 implicitly), but happy to revise to multi-anchor if you'd prefer to keep older builds working.

## Cross-rig credit

Discovered during cross-rig Cliff 1 testing on `noonghunna/club-3090` (RTX 3090, Qwen3.6-27B, TQ3 KV). The silent no-op was the difference between "P101 should help here per the docs" and "P101 has no observable effect" in our bisection.
