### PR TITLE
Fix PN12 anchor drift on vLLM dev205+ (silent no-op)

### DIFF
--- a/vllm/_genesis/wiring/patch_N12_ffn_intermediate_pool.py
+++ b/vllm/_genesis/wiring/patch_N12_ffn_intermediate_pool.py
@@ -101,30 +101,48 @@ GENESIS_PN12_MARKER = (
 
 
 # ─── Sub-patch: replace SiluAndMul.forward_cuda body ──────────────────────
-# Anchor matches the exact 4-line body:
-#     def forward_cuda(self, x: torch.Tensor) -> torch.Tensor:
-#         d = x.shape[-1] // 2
-#         output_shape = x.shape[:-1] + (d,)
-#         out = torch.empty(output_shape, dtype=x.dtype, device=x.device)
-#         self.op(out, x)
-#         return out
+#
+# Anchor strategy: include `forward_native` (which is unique to SiluAndMul —
+# MulAndSilu has the inverted-arg variant) as the disambiguating prefix, then
+# match the vanilla `forward_cuda` body. Trailing context (`forward_xpu` +
+# next class's `@CustomOp.register(...)` decorator) is intentionally NOT in
+# the anchor — that section was the brittleness that broke this patch on
+# vLLM dev205+ when MulAndSilu was inserted between SiluAndMul and
+# SiluAndMulWithClamp.
+#
+# This anchor stays valid as long as upstream keeps:
+#   - SiluAndMul's `forward_native` body unchanged (silu(x[:d]) * x[d:])
+#   - SiluAndMul's `forward_cuda` body the vanilla `torch.empty()` form
+# It is robust to: any decorator / class reordering after SiluAndMul,
+# insertion of `MulAndSilu` and similar inverted variants, addition of
+# new `forward_*` methods after `forward_cuda`, etc.
+#
+# If vllm#34207 lands and rewrites the body to `silu_and_mul.out()` form,
+# the anchor self-skips (vanilla body no longer matches) — same drift
+# behavior as the original.
 
 PN12_SILU_ANCHOR = (
+    "    @staticmethod\n"
+    "    def forward_native(x: torch.Tensor) -> torch.Tensor:\n"
+    '        """PyTorch-native implementation equivalent to forward()."""\n'
+    "        d = x.shape[-1] // 2\n"
+    "        return F.silu(x[..., :d]) * x[..., d:]\n"
+    "\n"
     "    def forward_cuda(self, x: torch.Tensor) -> torch.Tensor:\n"
     "        d = x.shape[-1] // 2\n"
     "        output_shape = x.shape[:-1] + (d,)\n"
     "        out = torch.empty(output_shape, dtype=x.dtype, device=x.device)\n"
     "        self.op(out, x)\n"
     "        return out\n"
-    "\n"
-    "    def forward_xpu(self, x: torch.Tensor) -> torch.Tensor:\n"
-    "        return self.forward_cuda(x)\n"
-    "\n"
-    "\n"
-    "@CustomOp.register(\"silu_and_mul_with_clamp\")\n"
 )
 
 PN12_SILU_REPLACEMENT = (
+    "    @staticmethod\n"
+    "    def forward_native(x: torch.Tensor) -> torch.Tensor:\n"
+    '        """PyTorch-native implementation equivalent to forward()."""\n'
+    "        d = x.shape[-1] // 2\n"
+    "        return F.silu(x[..., :d]) * x[..., d:]\n"
+    "\n"
     "    def forward_cuda(self, x: torch.Tensor) -> torch.Tensor:\n"
     "        # [Genesis PN12 FFN intermediate pool — Cliff 1 fix on TQ3]\n"
     "        # Pool the [M, d] BF16 transient across layers instead of\n"
@@ -154,12 +172,6 @@ PN12_SILU_REPLACEMENT = (
     "            )\n"
     "        self.op(out, x)\n"
     "        return out\n"
-    "\n"
-    "    def forward_xpu(self, x: torch.Tensor) -> torch.Tensor:\n"
-    "        return self.forward_cuda(x)\n"
-    "\n"
-    "\n"
-    "@CustomOp.register(\"silu_and_mul_with_clamp\")\n"
 )
 
 


### PR DESCRIPTION
## Summary

PN12's text-replace anchor doesn't match the current upstream `vllm/model_executor/layers/activation.py` on vLLM dev205+, so the patch silently no-ops. `apply_all` reports `"PN12 applied"` because `TextPatcher.apply()` returns without raising, but the installed file is unchanged.

This is the same anchor-drift class as P101 (PR #12) — same patcher, same silent-success behavior on a missed match.

## Symptom

After enabling `GENESIS_ENABLE_PN12_FFN_INTERMEDIATE_POOL=1` on a current vLLM nightly:

```
[INFO:genesis.apply_all] [Genesis] applied: PN12 FFN intermediate pool ...
```

But the installed `activation.py` still has the vanilla `SiluAndMul.forward_cuda` body:

```python
def forward_cuda(self, x: torch.Tensor) -> torch.Tensor:
    d = x.shape[-1] // 2
    output_shape = x.shape[:-1] + (d,)
    out = torch.empty(output_shape, dtype=x.dtype, device=x.device)
    self.op(out, x)
    return out
```

No `Genesis PN12` marker, no `FFNIntermediateCache` import. Every FFN forward fresh-allocates `[max_num_batched_tokens, intermediate_size]` (~138 MiB on Qwen3.6-27B with `max_num_batched_tokens=4128`) per layer-step. Cliff 1 mechanism B fires at the first chunked-prefill step at high mem-util.

## Root cause

PN12's anchor expects the next decorator after `SiluAndMul` to be `@CustomOp.register("silu_and_mul_with_clamp")`. In dev205+, `MulAndSilu` (the inverted-arg variant) now occupies that slot. The text-patch regex / string match fails and no replacement is performed. Because `TextPatch` returns success when no lines match (idempotency-friendly behavior), the failure is silent.

## Fix

Re-anchor PN12 to a class-scoped match against `class SiluAndMul(...)` directly, so the patch is robust to surrounding decorator and class-order churn. The pooled-output body and `FFNIntermediateCache` plumbing are unchanged — design intent is preserved exactly.

## Verification

Tested on RTX 3090 single-card + Qwen3.6-27B AutoRound INT4 + vLLM `dev205+g07351e088` + Genesis v7.62.x with the full Cliff-1 stack:

- `--max-model-len 205000`, `--max-num-batched-tokens 4128`, `--num-gpu-blocks-override 50`
- MTP n=3
- `GENESIS_ENABLE_P101=1` (anchor-fixed via PR #12 fork), `GENESIS_ENABLE_P103=1`, `GENESIS_ENABLE_PN12_FFN_INTERMEDIATE_POOL=1`, `GENESIS_ENABLE_PN13_CUDA_GRAPH_LAMBDA_ARITY=1`

After the anchor fix, the installed `activation.py` shows:
- `Genesis PN12` marker present
- `FFNIntermediateCache` import present
- `SiluAndMul.forward_cuda` uses the pooled-output body

Result on the previously-failing 25K-token tool-prefill stress (`scripts/verify-stress.sh`):
- Pre-fix: OOM at `empty_strided_cuda((s18, 17408))`, 138 MiB allocate / 130 MiB free
- Post-fix: 643-char text response, `finish_reason=stop`
- `verify-full.sh`: all 8 functional checks pass
- MTP acceptance length: 2.38

Independent retest (separate boot, fresh container) reproduced the closure.

## Why this is the missing piece for Cliff 1 mech B

We'd previously concluded (incorrectly) that PN12 was *partial* — that pooling only the `SiluAndMul` output left the `gate_up_proj` upstream allocation as the binding constraint. That analysis was based on an OOM signature observed with PN12 nominally enabled. We hadn't grep'd the live `activation.py` for the patch marker.

Once the anchor is repaired and PN12 actually applies, mech B closes at 205K with the existing stack. **The original PN12 design intent is correct as-is** — pool the SiluAndMul output, that's enough. No `gate_up_proj` extension needed.

## Note on anchor health as a class of issue

Two consecutive bisections on dev205+ (P101, then PN12) found the same failure mode: anchor stale, `TextPatch` returns success without applying, downstream behavior misattributes. Recommendation either way Sandermage prefers:

1. **Multi-anchor TextPatch** — supply alternative anchors covering recent + older upstream forms; first match wins. Keeps both vLLM lines working.
2. **Verification step in `apply_all`** — after a `TextPatch.apply()`, grep the target file for an expected post-patch marker before logging `"applied"`. Promotes anchor drift from silent to loud.

I left this PR as a single-anchor change matching the most recent vLLM form (option 2 implicitly), but happy to revise to multi-anchor if you'd prefer to keep older builds working.

## Cross-rig credit

Discovered during cross-rig Cliff 1 testing on `noonghunna/club-3090` (RTX 3090, Qwen3.6-27B, TQ3 KV). Documented in [`docs/CLIFFS.md`](https://github.com/noonghunna/club-3090/blob/cliff1-fa-clamp/docs/CLIFFS.md) with full diagnostic walk-through.
