### PR TITLE
feat(PN34): auto-enable for TurboQuant KV + spec-decode via config-detect

### DIFF
--- a/vllm/_genesis/config_detect.py
+++ b/vllm/_genesis/config_detect.py
@@ -143,6 +143,35 @@ def _probe_spec_decode_from_argv() -> dict[str, Any] | None:
     return out
 
 
+def _probe_tq_kv_from_argv() -> str | None:
+    """Fallback: probe argv for --kv-cache-dtype when called before vllm
+    config is constructed (e.g. apply_all phase). Returns the dtype string
+    (e.g. 'turboquant_4bit_nc') or None if flag not found.
+
+    Sources tried in order:
+      1. GENESIS_FORCE_KV_DTYPE env (operator override)
+      2. own sys.argv
+      3. /proc/1/cmdline (Docker entrypoint: apply_all then vllm serve)
+    """
+    import os
+    forced = os.environ.get("GENESIS_FORCE_KV_DTYPE", "").strip()
+    if forced and forced.lower() not in ("0", "false", "no", "off"):
+        return forced
+    import sys
+    import re
+    argv_parts = [" ".join(sys.argv)]
+    try:
+        with open("/proc/1/cmdline", "rb") as f:
+            argv_parts.append(f.read().replace(b"\x00", b" ").decode(errors="replace"))
+    except (OSError, IOError):
+        pass
+    argv = " ".join(argv_parts)
+    m = re.search(r"--kv-cache-dtype[=\s]+(\S+)", argv)
+    if m:
+        return m.group(1).strip("'\"")
+    return None
+
+
 def _probe_spec_decode(cfg: Any) -> dict[str, Any]:
     """Detect whether spec-decode is configured + which method + N."""
     out: dict[str, Any] = {"spec_decode_enabled": False}
@@ -402,6 +431,47 @@ def _recommend_for_patches(profile: dict[str, Any]) -> dict[str, Any]:
     else:
         rec["P37"] = "neutral"  # already opt-in via GENESIS_ENABLE_P37
 
+    # PN34: WorkspaceManager runtime lock relaxation (PN33 companion).
+    #
+    # PN33 fixes _dummy_sampler_run to warm up with K draft tokens, correctly
+    # sizing the rejection-sampler footprint. But the MTP drafter's
+    # _decode_attention runs in a SEPARATE workspace context that is never
+    # warmed up: the drafter forward pass is called during proposal (inference
+    # time), not during the profile_run that locks the workspace. The drafter's
+    # workspace is therefore locked at 0 bytes, and _decode_attention raises:
+    #
+    #   AssertionError: Workspace is locked but allocation from
+    #   'turboquant_attn.py:935:_decode_attention' requires 0.76 MB,
+    #   current size is 0.00 MB. Workspace growth is not allowed after locking.
+    #
+    # This is deterministic for any TQ-KV + spec-decode config. PN34 relaxes
+    # the strict assertion to WARN+grow so the drafter can allocate on-demand.
+    # The workspace manager itself handles growth correctly — the lock is purely
+    # an assertion, not a correctness guarantee (see workspace.py history).
+    #
+    # Auto-enable when all three conditions hold:
+    #   1. TurboQuant KV is active (the problematic attention backend)
+    #   2. Any spec-decode method is configured (drafter forward pass runs)
+    #   3. WorkspaceManager is present (the assertion exists in this vLLM build)
+    #
+    # Retires when vllm#40706 (pre-reserve drafter TQ workspace at warmup) lands.
+    kv_dtype = (profile.get("kv_cache_dtype") or "").lower()
+    workspace_manager_present = profile.get("workspace_manager_present", False)
+    is_tq_kv = "turboquant" in kv_dtype
+    if is_tq_kv and spec_decode and workspace_manager_present:
+        rec["PN34"] = (
+            "apply:TQ KV + spec-decode — MTP drafter _decode_attention runs in "
+            "a workspace context locked at 0 bytes (drafter path not covered by "
+            "PN33 sampler warmup fix). PN34 relaxes AssertionError to WARN+grow. "
+            "See vllm#40706 for upstream root-cause fix."
+        )
+    elif not is_tq_kv:
+        rec["PN34"] = "skip:no TurboQuant KV — workspace lock assertion never triggered"
+    elif not spec_decode:
+        rec["PN34"] = "skip:no spec-decode — no drafter forward pass, workspace lock safe"
+    else:
+        rec["PN34"] = "skip:WorkspaceManager not present in this vLLM build"
+
     return rec
 
 
@@ -458,6 +528,9 @@ def get_runtime_profile() -> dict[str, Any]:
             for k, v in argv_spec.items():
                 if k != "spec_decode_enabled":
                     profile[k] = v
+        argv_kv_dtype = _probe_tq_kv_from_argv()
+        if argv_kv_dtype:
+            profile["kv_cache_dtype"] = argv_kv_dtype
         profile["recommendations"] = _recommend_for_patches(profile)
         # H3 fix: cache the unresolved profile too. Saves ~33 patches × 5
         # source-file-read probes = ~100 ms boot time. Re-probe trigger at

--- a/vllm/_genesis/dispatcher.py
+++ b/vllm/_genesis/dispatcher.py
@@ -2147,6 +2147,23 @@ def should_apply(patch_id: str) -> tuple[bool, str]:
                 f"opt-in only AND empirically deprecated — "
                 f"keeping skip; set {env_flag}=1 only for diagnostics"
             )
+        # Config-detect auto-enable: if the runtime profile strongly recommends
+        # this patch ("apply"), engage it even without the env flag. This allows
+        # patches like PN34 to auto-enable on configs where they are always
+        # required (e.g. TQ + spec-decode) without forcing every operator to
+        # discover and set the env flag manually.
+        # Operators can suppress auto-enable via GENESIS_DISABLE_<PATCH_ID>=1,
+        # e.g. GENESIS_DISABLE_PN34=1 to keep PN34 off even on TQ+spec-decode.
+        disable_env = f"GENESIS_DISABLE_{patch_id}"
+        if os.environ.get(disable_env, "").strip().lower() in ("1", "true", "yes", "on"):
+            return False, f"suppressed via {disable_env}=1"
+        try:
+            from vllm._genesis.config_detect import recommend
+            cd_verdict, cd_reason = recommend(patch_id)
+            if cd_verdict == "apply":
+                return True, f"config-detect auto-enable: {cd_reason}"
+        except Exception:
+            pass
         return False, f"opt-in only — set {env_flag}=1 to engage"
 
     # default_on=True: enforce applies_to as Layer 2 HARD skip.

--- a/vllm/_genesis/tests/test_pN34_workspace_lock_relax.py
+++ b/vllm/_genesis/tests/test_pN34_workspace_lock_relax.py
@@ -59,15 +59,16 @@ def test_pn34_replacement_relaxes_to_warn_plus_grow():
     assert "NameError" in PN34_REPLACEMENT
 
 
-def test_pn34_skips_when_env_off(monkeypatch):
-    monkeypatch.delenv(
-        "GENESIS_ENABLE_PN34_WORKSPACE_LOCK_RELAX", raising=False
-    )
-    from vllm._genesis.wiring.perf_hotfix.patch_N34_workspace_lock_runtime_relax import (
-        apply,
-    )
-    status, reason = apply()
-    assert status == "skipped"
+def test_pn34_skips_when_env_off_and_config_neutral(monkeypatch):
+    """Without env flag AND with config-detect returning neutral, PN34 skips."""
+    monkeypatch.delenv("GENESIS_ENABLE_PN34_WORKSPACE_LOCK_RELAX", raising=False)
+    monkeypatch.delenv("GENESIS_DISABLE_PN34", raising=False)
+    # Override config-detect to return neutral (non-TQ config)
+    import vllm._genesis.config_detect as cd
+    monkeypatch.setattr(cd, "recommend", lambda pid: ("neutral", "no TQ KV"))
+    from vllm._genesis import dispatcher
+    decision, reason = dispatcher.should_apply("PN34")
+    assert decision is False
     assert "opt-in" in reason.lower()
 
 
@@ -124,3 +125,164 @@ def test_pn34_documents_upstream_retirement_path():
     )
     src = inspect.getsource(mod)
     assert "40706" in src  # vllm#40706 = TQ scratch dedup
+
+
+# ── Auto-enable via config-detect (new behavior) ─────────────────────────
+
+
+def test_pn34_config_detect_recommends_apply_for_tq_spec(monkeypatch):
+    """config_detect recommends 'apply' when TQ KV + spec-decode + WorkspaceManager."""
+    from vllm._genesis import config_detect
+
+    fake_profile = {
+        "kv_cache_dtype": "turboquant_4bit_nc",
+        "spec_decode_enabled": True,
+        "workspace_manager_present": True,
+        "max_num_seqs": 4,
+        "pr40798_active": False,
+        "pr40792_active": False,
+        "pr40384_active": False,
+        "pr40074_active": False,
+        "cudagraph_capture_active": True,
+    }
+    monkeypatch.setattr(config_detect, "_CACHED_PROFILE", None)
+
+    with monkeypatch.context() as mp:
+        mp.setattr(config_detect, "_try_get_vllm_config", lambda: object())
+        mp.setattr(config_detect, "_probe_scheduler", lambda cfg: {})
+        mp.setattr(config_detect, "_probe_spec_decode", lambda cfg: {
+            "spec_decode_enabled": True,
+        })
+        mp.setattr(config_detect, "_probe_compilation", lambda cfg: {
+            "cudagraph_capture_active": True,
+        })
+        mp.setattr(config_detect, "_probe_cache", lambda cfg: {
+            "kv_cache_dtype": "turboquant_4bit_nc",
+        })
+        mp.setattr(config_detect, "_probe_pr40384_active", lambda: False)
+        mp.setattr(config_detect, "_probe_pr40074_active", lambda: False)
+        mp.setattr(config_detect, "_probe_pr40798_active", lambda: False)
+        mp.setattr(config_detect, "_probe_pr40792_active", lambda: False)
+        mp.setattr(config_detect, "_probe_workspace_manager_present", lambda: True)
+
+        profile = config_detect.get_runtime_profile()
+
+    verdict, reason = config_detect.recommend("PN34")
+    assert verdict == "apply", f"Expected 'apply', got {verdict!r}: {reason}"
+    assert "TQ KV" in reason or "turboquant" in reason.lower() or "spec-decode" in reason
+
+
+def test_pn34_config_detect_skips_without_spec_decode(monkeypatch):
+    """config_detect skips PN34 when TQ KV but no spec-decode."""
+    from vllm._genesis import config_detect
+
+    monkeypatch.setattr(config_detect, "_CACHED_PROFILE", None)
+
+    with monkeypatch.context() as mp:
+        mp.setattr(config_detect, "_try_get_vllm_config", lambda: object())
+        mp.setattr(config_detect, "_probe_scheduler", lambda cfg: {})
+        mp.setattr(config_detect, "_probe_spec_decode", lambda cfg: {
+            "spec_decode_enabled": False,
+        })
+        mp.setattr(config_detect, "_probe_compilation", lambda cfg: {
+            "cudagraph_capture_active": False,
+        })
+        mp.setattr(config_detect, "_probe_cache", lambda cfg: {
+            "kv_cache_dtype": "turboquant_4bit_nc",
+        })
+        mp.setattr(config_detect, "_probe_pr40384_active", lambda: False)
+        mp.setattr(config_detect, "_probe_pr40074_active", lambda: False)
+        mp.setattr(config_detect, "_probe_pr40798_active", lambda: False)
+        mp.setattr(config_detect, "_probe_pr40792_active", lambda: False)
+        mp.setattr(config_detect, "_probe_workspace_manager_present", lambda: True)
+
+        config_detect.get_runtime_profile()
+
+    verdict, _ = config_detect.recommend("PN34")
+    assert verdict == "skip", f"Expected 'skip' without spec-decode, got {verdict!r}"
+
+
+def test_pn34_config_detect_skips_without_tq(monkeypatch):
+    """config_detect skips PN34 when spec-decode but no TQ KV."""
+    from vllm._genesis import config_detect
+
+    monkeypatch.setattr(config_detect, "_CACHED_PROFILE", None)
+
+    with monkeypatch.context() as mp:
+        mp.setattr(config_detect, "_try_get_vllm_config", lambda: object())
+        mp.setattr(config_detect, "_probe_scheduler", lambda cfg: {})
+        mp.setattr(config_detect, "_probe_spec_decode", lambda cfg: {
+            "spec_decode_enabled": True,
+        })
+        mp.setattr(config_detect, "_probe_compilation", lambda cfg: {
+            "cudagraph_capture_active": True,
+        })
+        mp.setattr(config_detect, "_probe_cache", lambda cfg: {
+            "kv_cache_dtype": "bfloat16",
+        })
+        mp.setattr(config_detect, "_probe_pr40384_active", lambda: False)
+        mp.setattr(config_detect, "_probe_pr40074_active", lambda: False)
+        mp.setattr(config_detect, "_probe_pr40798_active", lambda: False)
+        mp.setattr(config_detect, "_probe_pr40792_active", lambda: False)
+        mp.setattr(config_detect, "_probe_workspace_manager_present", lambda: True)
+
+        config_detect.get_runtime_profile()
+
+    verdict, _ = config_detect.recommend("PN34")
+    assert verdict == "skip", f"Expected 'skip' without TQ, got {verdict!r}"
+
+
+def test_pn34_disable_env_suppresses_auto_enable(monkeypatch):
+    """GENESIS_DISABLE_PN34=1 suppresses config-detect auto-enable."""
+    monkeypatch.delenv("GENESIS_ENABLE_PN34_WORKSPACE_LOCK_RELAX", raising=False)
+    monkeypatch.setenv("GENESIS_DISABLE_PN34", "1")
+
+    from vllm._genesis import dispatcher
+    decision, reason = dispatcher.should_apply("PN34")
+    assert decision is False
+    assert "PN34" in reason
+
+
+def test_pn34_tq_kv_argv_probe_detects_turboquant(monkeypatch):
+    """_probe_tq_kv_from_argv reads --kv-cache-dtype from sys.argv."""
+    import sys
+    monkeypatch.setattr(sys, "argv", [
+        "apply_all",
+        "--kv-cache-dtype", "turboquant_4bit_nc",
+        "--speculative-config", '{"method":"qwen3_next_mtp","num_speculative_tokens":4}',
+    ])
+    from vllm._genesis.config_detect import _probe_tq_kv_from_argv
+    result = _probe_tq_kv_from_argv()
+    assert result == "turboquant_4bit_nc"
+
+
+def test_pn34_tq_kv_argv_probe_returns_none_for_bfloat16(monkeypatch, tmp_path):
+    """_probe_tq_kv_from_argv returns None when no --kv-cache-dtype in argv or proc."""
+    import sys, builtins
+    monkeypatch.setattr(sys, "argv", ["apply_all", "--dtype", "bfloat16"])
+    # Stub out /proc/1/cmdline so it doesn't bleed in from the container launch args
+    original_open = builtins.open
+    def patched_open(path, *args, **kwargs):
+        if str(path) == "/proc/1/cmdline":
+            import io
+            return io.BytesIO(b"python3\x00apply_all\x00--dtype\x00bfloat16\x00")
+        return original_open(path, *args, **kwargs)
+    monkeypatch.setattr(builtins, "open", patched_open)
+    from vllm._genesis.config_detect import _probe_tq_kv_from_argv
+    result = _probe_tq_kv_from_argv()
+    assert result is None
+
+
+def test_pn34_auto_enable_via_dispatcher_when_config_recommends(monkeypatch):
+    """dispatcher.should_apply auto-enables PN34 when config_detect returns 'apply'."""
+    monkeypatch.delenv("GENESIS_ENABLE_PN34_WORKSPACE_LOCK_RELAX", raising=False)
+    monkeypatch.delenv("GENESIS_DISABLE_PN34", raising=False)
+
+    from vllm._genesis import dispatcher
+    import vllm._genesis.config_detect as cd
+
+    monkeypatch.setattr(cd, "recommend", lambda pid: ("apply", "TQ KV + spec-decode") if pid == "PN34" else ("neutral", ""))
+
+    decision, reason = dispatcher.should_apply("PN34")
+    assert decision is True
+    assert "config-detect auto-enable" in reason


### PR DESCRIPTION
## Problem

TurboQuant KV (\`--kv-cache-dtype turboquant_4bit_nc\`) combined with any spec-decode method (MTP, ngram, EAGLE) crashes deterministically on first inference with:

\`\`\`
AssertionError: Workspace is locked but allocation from
'turboquant_attn.py:935:_decode_attention' requires 0.76 MB,
current size is 0.00 MB. Workspace growth is not allowed after locking.
\`\`\`

This fires during the **MTP drafter's forward pass** (\`qwen3_5_mtp.py:417\`), not the target model's verify step.

## Root cause

PN33 fixes `_dummy_sampler_run` to use K draft tokens instead of 1, correctly sizing the rejection-sampler workspace. But the MTP drafter's `_decode_attention` runs in a **separate workspace context** that is never warmed up:

- The drafter forward pass is called at inference time (during proposal), not during `profile_run`
- The workspace for that context is therefore locked at **0 bytes**
- PN33 covers the sampler path; it does not reach the drafter's TQ attention workspace

Neither P65, P67, P98, P101, nor PN33 fixes this. PN34 does — it relaxes the strict assertion to WARN+grow, allowing the drafter to allocate workspace on-demand. The underlying allocator handles growth correctly; the lock was purely a debugging assertion.

## Fix

**`config_detect.py`**: `_recommend_for_patches` returns `"apply"` for PN34 when TQ KV + spec-decode + WorkspaceManager are all detected. Because `apply_all` runs before vLLM config is constructed, `kv_cache_dtype` is read via `_probe_tq_kv_from_argv()` from `sys.argv` / `/proc/1/cmdline` — same pattern as the existing spec-decode argv probe.

**`dispatcher.py`**: `should_apply()` for opt-in patches now consults `config_detect.recommend()` before returning "opt-in only". If the recommendation is `"apply"`, the patch auto-enables without requiring the operator to set `GENESIS_ENABLE_PN34_WORKSPACE_LOCK_RELAX=1`. Operators can suppress via `GENESIS_DISABLE_PN34=1`.

## Production confirmation

Confirmed working on:
- **Model**: `cyankiwi/Qwen3.6-27B-AWQ-BF16-INT4` + `--kv-cache-dtype turboquant_4bit_nc` + MTP K=4
- **Hardware**: NVIDIA A40 (SM 8.6, 48 GB), DP=1 TP=1
- **vLLM**: `0.21.1rc1.dev262+g33d7cbe02`

At boot, PN34 auto-enables via config_detect without any env flag:
\`\`\`
[Genesis Dispatcher] APPLY PN34 | config-detect auto-enable: TQ KV + spec-decode —
MTP drafter _decode_attention runs in a workspace context locked at 0 bytes
\`\`\`

Inference confirmed end-to-end on 2026-05-25 with P67 enabled:
\`\`\`
vllm:generation_tokens_total{model_name="qwen36-27b-multi"} 320.0
\`\`\`

> **Note:** The earlier "production confirmation" (overnight, 2026-05-25) was incomplete. PN34 eliminated the `AssertionError` crash, but a separate P67b OOB bug was silently corrupting inference: `_tq_mid_o_buf` is allocated by the decode path for `max_num_seqs` rows (4), but K+1 spec-verify creates `B×K1 = 4×5 = 20` synthetic rows → `cudaErrorIllegalAddress` → CUDA stream corrupts → model returns HTTP 200 with an empty body and `generation_tokens_total` stays at 0. This was fixed separately in `patch_67b_spec_verify_routing.py` (v7.63.x, credit @Quentin-M) before the final confirmation above. Diagnostic: always verify `vllm:generation_tokens_total` — HTTP 200 alone is not sufficient.

No `AssertionError: Workspace is locked` crashes. No `_GENESIS_PN34_WORKSPACE_LOCK_WARNED` warnings (PN33 warmup correctly sizes the sampler path; PN34 is a safety net for the drafter path that PN33 doesn't reach).

**DFlash+TQ confirmed incompatible**: vLLM's attention selector hard-rejects it (`TURBOQUANT: [non-causal attention not supported]`). MTP+TQ is the only viable TQ+spec-decode configuration.

## Tests

17 tests in `test_pN34_workspace_lock_relax.py` — all pass:

- `test_pn34_config_detect_recommends_apply_for_tq_spec` — TQ+spec → "apply"
- `test_pn34_config_detect_skips_without_spec_decode` — TQ only → "skip"
- `test_pn34_config_detect_skips_without_tq` — spec only → "skip"
- `test_pn34_disable_env_suppresses_auto_enable` — GENESIS_DISABLE_PN34=1 works
- `test_pn34_tq_kv_argv_probe_detects_turboquant` — argv probe reads --kv-cache-dtype
- `test_pn34_tq_kv_argv_probe_returns_none_for_bfloat16` — no false positive
- `test_pn34_auto_enable_via_dispatcher_when_config_recommends` — full dispatcher path
- Plus the original 10 structural/wiring tests

## Notes

- Companion to PN33 — both address workspace under-counting at different layers (sampler warmup vs drafter attention)
- Retires when vllm#40706 (pre-reserve drafter TQ workspace at warmup) lands upstream
- The `dispatcher.py` change is generic: any future opt-in patch can auto-enable by returning `"apply"` from `config_detect`
- PN14 (GPU-aware DP LB) arrived in this branch from the same fork; bot review items (ID collision, NVML indexing, hot-path init) are valid and will be addressed in a dedicated follow-up PR